### PR TITLE
Occurrence ingestion adjustments

### DIFF
--- a/classes/OccurrenceUtilities.php
+++ b/classes/OccurrenceUtilities.php
@@ -527,16 +527,20 @@ class OccurrenceUtilities {
 		if(isset($recMap['latdeg']) && $recMap['latdeg'] && isset($recMap['lngdeg']) && $recMap['lngdeg']){
 			//Attempt to create decimal lat/long
 			if(is_numeric($recMap['latdeg']) && is_numeric($recMap['lngdeg']) && (!isset($recMap['decimallatitude']) || !isset($recMap['decimallongitude']))){
-				$latDec = $recMap['latdeg'];
+				$latDec = abs($recMap['latdeg']);
 				if(isset($recMap['latmin']) && $recMap['latmin'] && is_numeric($recMap['latmin'])) $latDec += $recMap['latmin']/60;
 				if(isset($recMap['latsec']) && $recMap['latsec'] && is_numeric($recMap['latsec'])) $latDec += $recMap['latsec']/3600;
-				if(isset($recMap['latns']) && stripos($recMap['latns'],'s') === 0 && $latDec > 0) $latDec *= -1;
-				$lngDec = $recMap['lngdeg'];
+				if($latDec > 0){
+					if(isset($recMap['latns']) && stripos($recMap['latns'],'s') === 0) $latDec *= -1;
+					elseif($recMap['latdeg'] < 0) $latDec *= -1;
+				}
+				$lngDec = abs($recMap['lngdeg']);
 				if(isset($recMap['lngmin']) && $recMap['lngmin'] && is_numeric($recMap['lngmin'])) $lngDec += $recMap['lngmin']/60;
 				if(isset($recMap['lngsec']) && $recMap['lngsec'] && is_numeric($recMap['lngsec'])) $lngDec += $recMap['lngsec']/3600;
-				if(isset($recMap['lngew']) && stripos($recMap['lngew'],'w') === 0  && $lngDec > 0) $lngDec *= -1;
 				if($lngDec > 0){
-					if(in_array(strtolower($recMap['country']), array('usa','united states','canada','mexico','panama'))) $lngDec *= -1;
+					if(isset($recMap['lngew']) && stripos($recMap['lngew'],'w') === 0) $lngDec *= -1;
+					elseif($recMap['lngdeg'] < 0) $lngDec *= -1;
+					elseif(in_array(strtolower($recMap['country']), array('usa','united states','canada','mexico','panama'))) $lngDec *= -1;
 				}
 				$recMap['decimallatitude'] = round($latDec,6);
 				$recMap['decimallongitude'] = round($lngDec,6);
@@ -544,11 +548,11 @@ class OccurrenceUtilities {
 			//Place into verbatim coord field
 			$vCoord = (isset($recMap['verbatimcoordinates'])?$recMap['verbatimcoordinates']:'');
 			if($vCoord) $vCoord .= '; ';
-			$vCoord .= $recMap['latdeg'].chr(167).' ';
+			$vCoord .= $recMap['latdeg'].chr(176).' ';
 			if(isset($recMap['latmin']) && $recMap['latmin']) $vCoord .= $recMap['latmin'].'m ';
 			if(isset($recMap['latsec']) && $recMap['latsec']) $vCoord .= $recMap['latsec'].'s ';
 			if(isset($recMap['latns'])) $vCoord .= $recMap['latns'].'; ';
-			$vCoord .= $recMap['lngdeg'].chr(167).' ';
+			$vCoord .= $recMap['lngdeg'].chr(176).' ';
 			if(isset($recMap['lngmin']) && $recMap['lngmin']) $vCoord .= $recMap['lngmin'].'m ';
 			if(isset($recMap['lngsec']) && $recMap['lngsec']) $vCoord .= $recMap['lngsec'].'s ';
 			if(isset($recMap['lngew'])) $vCoord .= $recMap['lngew'];

--- a/classes/SpecUploadBase.php
+++ b/classes/SpecUploadBase.php
@@ -106,7 +106,7 @@ class SpecUploadBase extends SpecUpload{
 		//Get uploadspectemp metadata
 		$skipOccurFields = array('dbpk','initialtimestamp','occid','collid','tidinterpreted','fieldnotes','coordinateprecision',
 			'verbatimcoordinatesystem','institutionid','collectionid','associatedoccurrences','datasetid','associatedreferences',
-			'previousidentifications','associatedsequences');
+			'previousidentifications','associatedsequences','storagelocation');
 		if($this->collMetadataArr['managementtype'] == 'Live Data' && $this->collMetadataArr['guidtarget'] != 'occurrenceId'){
 			//Do not import occurrenceID if dataset is a live dataset, unless occurrenceID is explicitly defined as the guidSource.
 			//This avoids the situtation where folks are exporting data from one collection and importing into their collection along with the other collection's occurrenceID GUID, which is very bad
@@ -181,7 +181,7 @@ class SpecUploadBase extends SpecUpload{
 			case $this->RESTOREBACKUP:
 			case $this->DIRECTUPLOAD:
 				//Get identification metadata
-				$skipDetFields = array('detid','occid','tidinterpreted','idbyid','appliedstatus','sortsequence','sourceidentifier','initialtimestamp');
+				$skipDetFields = array('detid','occid','tidinterpreted','idbyid','appliedstatus','sortsequence','initialtimestamp');
 				if($this->uploadType == $this->RESTOREBACKUP){
 					unset($skipDetFields);
 					$skipDetFields = array();
@@ -1370,7 +1370,7 @@ class SpecUploadBase extends SpecUpload{
 
 				if((isset($recMap['identifiedby']) && $recMap['identifiedby']) || (isset($recMap['dateidentified']) && $recMap['dateidentified']) || (isset($recMap['sciname']) && $recMap['sciname'])){
 					if(!isset($recMap['identifiedby']) || !$recMap['identifiedby']) $recMap['identifiedby'] = 'not specified';
-					if(!isset($recMap['dateidentified']) || $recMap['dateidentified']) $recMap['dateidentified'] = 'not specified';
+					if(!isset($recMap['dateidentified']) || !$recMap['dateidentified']) $recMap['dateidentified'] = 'not specified';
 					$sqlFragments = $this->getSqlFragments($recMap,$this->identFieldMap);
 					if($sqlFragments){
 						$sql = 'INSERT INTO uploaddetermtemp(collid'.$sqlFragments['fieldstr'].') VALUES('.$this->collId.$sqlFragments['valuestr'].')';

--- a/classes/SpecUploadDwca.php
+++ b/classes/SpecUploadDwca.php
@@ -426,8 +426,9 @@ class SpecUploadDwca extends SpecUploadBase{
 				else{
 					$this->delimiter = '';
 				}
-				if(isset($this->metaArr['occur']['fieldsEnclosedBy']) && $this->metaArr['occur']['fieldsEnclosedBy']){
+				if(isset($this->metaArr['occur']['fieldsEnclosedBy'])){
 					$this->enclosure = $this->metaArr['occur']['fieldsEnclosedBy'];
+					if($this->delimiter == "\t" && !$this->enclosure) $this->enclosure = chr(127);		//Needed to keep fgetcsv from reverting back to " as the default enclosure character
 				}
 				if(isset($this->metaArr['occur']['encoding']) && $this->metaArr['occur']['encoding']){
 					$this->encoding = strtolower(str_replace('-','',$this->metaArr['occur']['encoding']));

--- a/collections/misc/rarespecies.php
+++ b/collections/misc/rarespecies.php
@@ -1,0 +1,4 @@
+<?php
+header("verify-v1: wpUXDFh2c7hSqw9SyMMem2AgJ4QIn01/JBu9sJOX6AM=");
+header("Location: protectedspecies.php");
+?>

--- a/css/base.css
+++ b/css/base.css
@@ -59,12 +59,12 @@ form input {
 }
 
 a{
-	color: 		#2C405E;
+	color: 		#4a55b9;
     text-decoration: none;	
 }
 
 a:hover{
-	color: black;
+	color: #2C405E;
     text-decoration: underline;
 }
 


### PR DESCRIPTION
- Bug fix for incorrect calculation of decimal lat/long when DMS format is supplied with negative degrees dictating hemisphere
- improved support for imported tab-delimited files where text fields are not enclosed by quotes
- Temporarly remove not yet supported storageLocation from import mapping
- Bug fix that was interring with import of dateIdentified from DwC-A Identification History extension files
- Add sourceIdentifier as an import option for DwC image files
- Correct ASCII representation of degree symbol