### PR TITLE
Occurrence Search bug

### DIFF
--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -337,7 +337,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 		}
 		if(array_key_exists('catnum',$this->searchTermArr)){
 			$catStr = $this->cleanInStr($this->searchTermArr['catnum']);
-			$includeOtherCatNum = array_key_exists('othercatnum',$this->searchTermArr)?true:false;
+			$includeOtherCatNum = array_key_exists('includeothercatnum',$this->searchTermArr)?true:false;
 
 			$catArr = explode(',',str_replace(';',',',$catStr));
 			$betweenFrag = array();
@@ -728,7 +728,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			if($catNum){
 				$this->searchTermArr["catnum"] = $catNum;
 				if(array_key_exists("includeothercatnum",$_REQUEST)){
-					$this->searchTermArr["othercatnum"] = '1';
+					$this->searchTermArr["includeothercatnum"] = '1';
 				}
 			}
 			else{

--- a/collections/specprocessor/standalone_scripts/index.php
+++ b/collections/specprocessor/standalone_scripts/index.php
@@ -1,0 +1,39 @@
+<?php
+include_once('../config/symbini.php');
+header("Content-Type: text/html; charset=".$CHARSET);
+header("Location: ".$CLIENT_ROOT."/index.php");
+?>
+<html>
+	<head>
+		<title>Forbidden</title>
+		<?php
+		$activateJQuery = false;
+		if(file_exists($SERVER_ROOT.'/includes/head.php')){
+			include_once($SERVER_ROOT.'/includes/head.php');
+		}
+		else{
+			echo '<link href="'.$CLIENT_ROOT.'/css/base.css?ver=1" type="text/css" rel="stylesheet" />';
+			echo '<link href="'.$CLIENT_ROOT.'/css/main.css?ver=1" type="text/css" rel="stylesheet" />';
+		}
+		?>
+	</head>
+	<body>
+		<?php
+		$displayLeftMenu = true;
+		include($SERVER_ROOT.'/includes/header.php');
+		?>
+		<!-- This is inner text! -->
+		<div id="innertext">
+			<h1>Forbidden</h1>
+			<div style="font-weight:bold;">
+				You don't have permission to access this page.
+			</div>
+			<div style="font-weight:bold;margin:10px;">
+				<a href="<?php echo $CLIENT_ROOT; ?>/index.php">Return to index page</a>
+			</div>
+		</div>
+		<?php
+		include($SERVER_ROOT.'/includes/footer.php');
+		?>
+	</body>
+</html>


### PR DESCRIPTION
- Resolved issue of copy URL failing when catalog number is searched and the include otherCatalogNumbers option activated. In this case, the include otherCatalogNumbers option was failing to be inserted into the url properly