### PR TITLE
Trait search

### DIFF
--- a/classes/OccurrenceAttributeSearch.php
+++ b/classes/OccurrenceAttributeSearch.php
@@ -82,7 +82,7 @@ class OccurrenceAttributeSearch extends OccurrenceAttributes {
 					$innerStr .= ': <input name="traitid-'.$traitID.'[]" id="traitstateid-'.$sid.'" class="'.$classStr.'" type="text" value="'.$sid.'-'.($isCoded!==false?$isCoded:'').'" onchange="traitChanged(this)" style="width:50px" /> ';
 					if($depTraitIdArr){
 						foreach($depTraitIdArr as $depTraitId){
-							$innerStr .= $this->getTraitUnitString($depTraitId,$isCoded,trim($classStr.' child-'.$sid));
+							$innerStr .= $this->getTraitSearchHTML($depTraitId,$isCoded,trim($classStr.' child-'.$sid));
 						}
 					}
 				}
@@ -97,7 +97,7 @@ class OccurrenceAttributeSearch extends OccurrenceAttributes {
 					}
 					if($depTraitIdArr){
 						foreach($depTraitIdArr as $depTraitId){
-							$innerStr .= $this->getTraitUnitString($depTraitId,$isCoded,trim($classStr.' child-'.$sid));
+							$innerStr .= $this->getTraitSearchHTML($depTraitId,$isCoded,trim($classStr.' child-'.$sid));
 						}
 					}
 					if($controlType != 'select') $innerStr .= '</div>';

--- a/classes/OccurrenceAttributeSearch.php
+++ b/classes/OccurrenceAttributeSearch.php
@@ -1,0 +1,130 @@
+<?php
+include_once($SERVER_ROOT.'/classes/OccurrenceAttributes.php');
+
+class OccurrenceAttributeSearch extends OccurrenceAttributes {
+
+  //use $setAttributes = false in call to ->getTraitArr, if reverting to using OccurrenceAttributes class
+
+  //private $traitSearchArr = array();
+  public function __construct(){
+		parent::__construct('readonly');
+	}
+
+	public function __destruct(){
+		parent::__destruct();
+	}
+
+  public function getTraitSearchArr($traitID = null){
+    if($traitID) {
+      $traitIDArr = array_map('trim', explode(',', $traitID));
+      if (($key = array_search('0', $traitIDArr)) !== false) {
+          unset($traitIDArr[$key]);
+      } // this purges potential zeros from the array
+      $traitID = implode(',', $traitIDArr);
+      foreach($traitIDArr as $tid) {
+        if(!is_numeric($tid)) return null; // reject non-numeric IDs
+      }
+    }
+    unset($this->traitArr);
+    $this->traitArr = array();
+    $this->setTraitSearchArr($traitID);
+    $this->setTraitStates();
+    return $this->traitArr;
+  }
+
+  private function setTraitSearchArr($traitID){
+    $sql = 'SELECT traitid, traitname, traittype, units, description, refurl, notes, dynamicproperties FROM tmtraits WHERE traittype IN("UM","OM","TF","NU") ';
+    if($traitID) $sql .= 'AND (traitid IN('.$traitID.'))';
+    $rs = $this->conn->query($sql);
+    while($r = $rs->fetch_object()){
+      if(!isset($this->traitArr[$r->traitid])){
+        $this->traitArr[$r->traitid]['name'] = $r->traitname;
+        $this->traitArr[$r->traitid]['type'] = $r->traittype;
+        $this->traitArr[$r->traitid]['props'] = $r->dynamicproperties;
+        //Get dependent traits and append to return array
+        $this->setDependentTraits($r->traitid);
+      }
+    }
+    $rs->free();
+    return $this->traitArr;
+  }
+
+  public function echoTraitSearchForm($traitID){
+		echo $this->getTraitSearchHTML($traitID,true);
+	}
+
+	private function getTraitSearchHTML($traitID,$display,$classStr=''){
+		$controlType = '';
+		if($this->traitArr[$traitID]['props']){
+			$propArr = json_decode($this->traitArr[$traitID]['props'],true);
+			if(isset($propArr[0]['controlType'])) $controlType = $propArr[0]['controlType'];
+		}
+		$innerStr = '<div style="clear:both">';
+		if(isset($this->traitArr[$traitID]['states'])){
+			if($this->traitArr[$traitID]['type']=='TF'){
+				$innerStr .= '<div style="float:left;margin-left: 15px">'.$this->traitArr[$traitID]['name'].':</div>';
+				$innerStr .= '<div style="clear:both;margin-left: 25px">';
+			}
+			else $innerStr .= '<div style="float:left;">';
+			$attrStateArr = $this->traitArr[$traitID]['states'];
+			foreach($attrStateArr as $sid => $sArr){
+				$isCoded = false;
+				if(array_key_exists('coded',$sArr)){
+					if(is_numeric($sArr['coded'])) $isCoded = $sArr['coded'];
+					else $isCoded = true;
+					$this->stateCodedArr[$sid] = $sid;
+				}
+				$depTraitIdArr = array();
+				if(isset($sArr['dependTraitID']) && $sArr['dependTraitID']) $depTraitIdArr = $sArr['dependTraitID'];
+				if($this->traitArr[$traitID]['type']=='NU'){
+					$innerStr .= '<div title="'.$sArr['description'].'" style="clear:both">';
+					$innerStr .= $sArr['name'].
+					$innerStr .= ': <input name="traitid-'.$traitID.'[]" id="traitstateid-'.$sid.'" class="'.$classStr.'" type="text" value="'.$sid.'-'.($isCoded!==false?$isCoded:'').'" onchange="traitChanged(this)" style="width:50px" /> ';
+					if($depTraitIdArr){
+						foreach($depTraitIdArr as $depTraitId){
+							$innerStr .= $this->getTraitUnitString($depTraitId,$isCoded,trim($classStr.' child-'.$sid));
+						}
+					}
+				}
+				else{
+					if($controlType == 'checkbox' || $controlType == 'radio'){
+						$innerStr .= '<div title="'.$sArr['description'].'" style="clear:both">';
+						$innerStr .= '<input name="traitid-'.$traitID.'[]" id="traitstateid-'.$sid.'" class="'.$classStr.'" type="'.$controlType.'" value="'.$sid.'" '.($isCoded?'checked':'').' onchange="traitChanged(this)" /> ';
+						$innerStr .= $sArr['name'];
+					}
+					elseif($controlType == 'select'){
+						$innerStr .= '<option value="'.$sid.'" '.($isCoded?'selected':'').'>'.$sArr['name'].'</option>';
+					}
+					if($depTraitIdArr){
+						foreach($depTraitIdArr as $depTraitId){
+							$innerStr .= $this->getTraitUnitString($depTraitId,$isCoded,trim($classStr.' child-'.$sid));
+						}
+					}
+					if($controlType != 'select') $innerStr .= '</div>';
+				}
+			}
+			$innerStr .= '</div>';
+		}
+		$innerStr .= '</div>';
+		//Display if trait has been coded or is the first/base trait (e.g. $indend == 0)
+		$divClass = '';
+		if($classStr){
+			$classArr = explode(' ',$classStr);
+			$divClass = array_pop($classArr);
+		}
+		$outStr = '<div class="'.$divClass.'" style="margin-left:'.($classStr?'10':'').'px; display:'.($display?'block':'none').';">';
+		if($controlType == 'select'){
+			$outStr .= '<select name="stateid">';
+			$outStr .= '<option value="">Select State</option>';
+			$outStr .= '<option value="">------------------------------</option>';
+			$outStr .= $innerStr;
+			$outStr .= '</select>';
+		}
+		else{
+			$outStr .= $innerStr;
+		}
+		$outStr .= '</div>';
+		return $outStr;
+	}
+
+}

--- a/classes/OccurrenceAttributes.php
+++ b/classes/OccurrenceAttributes.php
@@ -4,7 +4,7 @@ include_once($SERVER_ROOT.'/classes/Manager.php');
 class OccurrenceAttributes extends Manager {
 
 	private $collidStr = 0;
-	private $traitArr = array();
+	protected $traitArr = array();
 	private $stateCodedArr = array();
 	private $reviewSqlBase;
 	private $occid = 0;
@@ -297,7 +297,7 @@ class OccurrenceAttributes extends Manager {
 		return $this->traitArr;
 	}
 
-	private function setDependentTraits($traitid){
+	protected function setDependentTraits($traitid){
 		$sql = 'SELECT DISTINCT s.traitid AS parenttraitid, d.parentstateid, d.traitid AS depTraitID '.
 			'FROM tmstates s INNER JOIN tmtraitdependencies d ON s.stateid = d.parentstateid '.
 			'WHERE (s.traitid = '.$traitid.')';
@@ -311,7 +311,7 @@ class OccurrenceAttributes extends Manager {
 		$rs->free();
 	}
 
-	private function setTraitStates(){
+	protected function setTraitStates(){
 		$sql = 'SELECT traitid, stateid, statename, description, notes, refurl FROM tmstates ';
 		if($this->traitArr) $sql .= 'WHERE traitid IN('.implode(',',array_keys($this->traitArr)).') ';
 		$sql .= 'ORDER BY traitid, sortseq, statecode ';

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -423,6 +423,21 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 				$this->displaySearchArr[] = 'includes cultivated/captive occurrences';
 			}
 		}
+		$anyTraitsHere = 0;
+		$traitSql = '';
+		foreach($this->searchTermArr as $stkey => $stval){
+			if("traitid-" == substr($stkey, 0, 8)){
+				if($stval){
+					if($anyTraitsHere == 1) { $traitSql .= ' OR '; }
+					$traitSql .= 'stateid = ' . $stval;
+					//$this->displaySearchArr[] = ''; // need to pull the trait name and state to fill this in
+					$anyTraitsHere = 1;
+				}
+			}
+		}
+		if($anyTraitsHere == 1) {
+			$sqlWhere .= 'AND (o.occid IN(SELECT occid FROM tmattributes WHERE ' . $traitSql . '))';
+		}
 		if($sqlWhere){
 			$this->sqlWhere = 'WHERE '.substr($sqlWhere,4);
 		}
@@ -830,6 +845,16 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			}
 			else{
 				unset($this->searchTermArr["includecult"]);
+			}
+		}
+		// Traits search: loop over all "traitid-" fields
+		foreach ($_REQUEST as $reqkey => $reqval){
+			if("traitid-" == substr($reqkey, 0, 8)){
+				if($reqval){
+					$this->searchTermArr[$reqkey] = $reqval[0];
+				} else {
+					unset($this->searchTermArr[$reqkey]);
+				}
 			}
 		}
 		$llPattern = '-?\d+\.{0,1}\d*';

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -2,10 +2,12 @@
 include_once('../config/symbini.php');
 include_once($SERVER_ROOT.'/content/lang/collections/harvestparams.'.$LANG_TAG.'.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceManager.php');
+include_once($SERVER_ROOT.'/classes/OccurrenceAttributes.php');
 header("Content-Type: text/html; charset=".$CHARSET);
 
 $collManager = new OccurrenceManager();
 $searchVar = $collManager->getQueryTermStr();
+$attribSearch = new OccurrenceAttributes();
 ?>
 <html>
 <head>
@@ -24,6 +26,7 @@ $searchVar = $collManager->getQueryTermStr();
 	<script src="../js/jquery-3.2.1.min.js?ver=3" type="text/javascript"></script>
 	<script src="../js/jquery-ui-1.12.1/jquery-ui.min.js?ver=3" type="text/javascript"></script>
 	<script src="../js/symb/collections.harvestparams.js?ver=180721" type="text/javascript"></script>
+	<script src="../js/symb/collections.traitsearch.js?ver=8" type="text/javascript"></script> <!-- Cotains serach-by-trait modifications -->
 	<script type="text/javascript">
 		$(document).ready(function() {
 			<?php
@@ -220,10 +223,15 @@ $searchVar = $collManager->getQueryTermStr();
 				<input type="text" id="eventdate2" size="32" name="eventdate2" style="width:100px;" value="" title="<?php echo $LANG['TITLE_TEXT_4']; ?>" />
 			</div>
 			<hr/>
-			<div style="float:right;">
-				<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
-				<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
-			</div>
+
+			<?php if(!isset($SEARCH_BY_TRAITS) || $SEARCH_BY_TRAITS == 0) { ?>
+				<div style="float:right;">
+					<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
+					<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
+					<div><button type="reset" style="width:100%" onclick="resetHarvestParamsForm()"><?php echo isset($LANG['BUTTON_RESET'])?$LANG['BUTTON_RESET']:'Reset Form'; ?></button></div>
+				</div>
+			<?php } ?>
+
 			<div>
 				<div style="font-weight:bold; font-size: 18px"><?php echo $LANG['SPECIMEN_HEADER']; ?></div>
 			</div>
@@ -244,6 +252,45 @@ $searchVar = $collManager->getQueryTermStr();
 			<div>
 				<input type='checkbox' name='includecult' value='1' /> <?php echo isset($LANG['INCLUDE_CULTIVATED'])?$LANG['INCLUDE_CULTIVATED']:'Include cultivated/captive occurrences'; ?>
 			</div>
+			<?php
+				if(isset($SEARCH_BY_TRAITS) && $SEARCH_BY_TRAITS != 0) {
+					$traitArr = $attribSearch->getTraitArr();
+					if($traitArr){
+			?>
+						<hr/>
+						<div style="float:right;">
+							<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
+							<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
+							<div><button type="reset" style="width:100%" onclick="resetHarvestParamsForm()"><?php echo isset($LANG['BUTTON_RESET'])?$LANG['BUTTON_RESET']:'Reset Form'; ?></button></div>
+						</div>
+						<div>
+							<div>
+								<p style="font-weight:bold; font-size: 18px"><?php echo $LANG['TRAIT_HEADER']; ?></p>
+								<p>Selecting multiple traits will return all records with at least one of those traits.</p>
+							</div>
+						</div>
+			<?php
+						foreach($traitArr as $traitID => $traitData){
+							if(!isset($traitData['dependentTrait'])) {
+			?>
+								<fieldset style="margin-top:20px">
+									<legend><b>Trait: <?php echo $traitData['name']; ?></b></legend>
+									<div style="float:right">
+										<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="Toggle attribute tree open/close">
+											<img class="triangleright" src="../images/triangleright.png" style="" />
+											<img class="triangledown" src="../images/triangledown.png" style="display:none" />
+										</div>
+									</div>
+									<div class="traitDiv" style="margin-left:5px;float:left">
+										<?php $attribSearch->echoFormTraits($traitID); ?>
+									</div>
+								</fieldset>
+			<?php
+							}
+						}
+					}
+				}
+			?>
 			<div>
 				<input type="hidden" name="reset" value="1" />
 				<input type="hidden" name="db" value="<?php echo $collManager->getSearchTerm('db'); ?>" />

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -2,12 +2,12 @@
 include_once('../config/symbini.php');
 include_once($SERVER_ROOT.'/content/lang/collections/harvestparams.'.$LANG_TAG.'.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceManager.php');
-include_once($SERVER_ROOT.'/classes/OccurrenceAttributes.php');
+include_once($SERVER_ROOT.'/classes/OccurrenceAttributeSearch.php');
 header("Content-Type: text/html; charset=".$CHARSET);
 
 $collManager = new OccurrenceManager();
 $searchVar = $collManager->getQueryTermStr();
-$attribSearch = new OccurrenceAttributes();
+$attribSearch = new OccurrenceAttributeSearch();
 ?>
 <html>
 <head>
@@ -252,12 +252,12 @@ $attribSearch = new OccurrenceAttributes();
 			<div>
 				<input type='checkbox' name='includecult' value='1' /> <?php echo isset($LANG['INCLUDE_CULTIVATED'])?$LANG['INCLUDE_CULTIVATED']:'Include cultivated/captive occurrences'; ?>
 			</div>
+			<hr/>
 			<?php
 				if(isset($SEARCH_BY_TRAITS) && $SEARCH_BY_TRAITS != 0) {
-					$traitArr = $attribSearch->getTraitArr();
+					$traitArr = $attribSearch->getTraitSearchArr($SEARCH_BY_TRAITS);
 					if($traitArr){
 			?>
-						<hr/>
 						<div style="float:right;">
 							<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
 							<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
@@ -267,6 +267,7 @@ $attribSearch = new OccurrenceAttributes();
 							<div>
 								<p style="font-weight:bold; font-size: 18px"><?php echo $LANG['TRAIT_HEADER']; ?></p>
 								<p>Selecting multiple traits will return all records with at least one of those traits.</p>
+								<input type="hidden" id="SearchByTraits" value="true">
 							</div>
 						</div>
 			<?php
@@ -285,6 +286,7 @@ $attribSearch = new OccurrenceAttributes();
 										<?php $attribSearch->echoFormTraits($traitID); ?>
 									</div>
 								</fieldset>
+								<hr/>
 			<?php
 							}
 						}

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -283,7 +283,7 @@ $attribSearch = new OccurrenceAttributeSearch();
 										</div>
 									</div>
 									<div class="traitDiv" style="margin-left:5px;float:left">
-										<?php $attribSearch->echoFormTraits($traitID); ?>
+										<?php $attribSearch->echoTraitSearchForm($traitID); ?>
 									</div>
 								</fieldset>
 								<hr/>

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -62,7 +62,8 @@ $DISPLAY_COMMON_NAMES = 1;			//Display common names in species profile page and 
 $ACTIVATE_EXSICCATI = 0;			//Activates exsiccati fields within data entry pages; adding link to exsiccati search tools to portal menu is recommended
 $ACTIVATE_GEOLOCATE_TOOLKIT = 0;	//Activates GeoLocate Toolkit located within the Processing Toolkit menu items
 $OCCUR_SECURITY_OPTION = 1;			//Occurrence security options supported: value 1-7; 1 = Locality security, 2 = Taxon security, 4 = Full security, 3 = L & T, 5 = L & F, 6 = T & F, 7 = all
-$SEARCH_BY_TRAITS = 0;			//Activates search fields for searching by traits if trait data have been encoded: 0 = trait search off, 1 = trait search on
+$SEARCH_BY_TRAITS = '0';			//Activates search fields for searching by traits (if trait data have been encoded): 0 = trait search off; any number of non-zeros separated by commas (e.g., '1,6') = trait search on for the traits with these id numbers in table tmtraits.
+
 
 $IGSN_ACTIVATION = 0;
 

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -62,6 +62,7 @@ $DISPLAY_COMMON_NAMES = 1;			//Display common names in species profile page and 
 $ACTIVATE_EXSICCATI = 0;			//Activates exsiccati fields within data entry pages; adding link to exsiccati search tools to portal menu is recommended
 $ACTIVATE_GEOLOCATE_TOOLKIT = 0;	//Activates GeoLocate Toolkit located within the Processing Toolkit menu items
 $OCCUR_SECURITY_OPTION = 1;			//Occurrence security options supported: value 1-7; 1 = Locality security, 2 = Taxon security, 4 = Full security, 3 = L & T, 5 = L & F, 6 = T & F, 7 = all
+$SEARCH_BY_TRAITS = 0;			//Activates search fields for searching by traits if trait data have been encoded: 0 = trait search off, 1 = trait search on
 
 $IGSN_ACTIVATION = 0;
 

--- a/content/lang/collections/harvestparams.en.php
+++ b/content/lang/collections/harvestparams.en.php
@@ -57,4 +57,5 @@ $LANG['TYPE'] = 'Limit to Type Specimens';
 $LANG['HAS_IMAGE'] = 'Limit to Specimens with Images';
 $LANG['HAS_GENETIC'] = 'Limit to Specimens with Genetic Data';
 $LANG['INCLUDE_CULTIVATED'] = 'Include cultivated/captive occurrences';
+$LANG['TRAIT_HEADER'] = 'Trait Criteria';
 ?>

--- a/content/lang/collections/harvestparams.es.php
+++ b/content/lang/collections/harvestparams.es.php
@@ -57,4 +57,5 @@ $LANG['TYPE'] = 'Limitar a ejemplares tipo';
 $LANG['HAS_IMAGE'] = 'Limitar a ejemplares con im&aacute;genes';
 $LANG['HAS_GENETIC'] = 'Limitar a ejemplares con datos gen&eacute;ticos';
 $LANG['INCLUDE_CULTIVATED'] = 'Incluye ejemplares cultivadas/cautivas';
+$LANG['TRAIT_HEADER'] = 'Criterios de Rasgos';
 ?>

--- a/js/symb/collections.harvestparams.js
+++ b/js/symb/collections.harvestparams.js
@@ -1,6 +1,6 @@
 function displayTableView(f){
 	f.action = "listtabledisplay.php";
-	f.submit();	
+	f.submit();
 }
 
 function cleanNumericInput(formElem){
@@ -17,8 +17,33 @@ function checkHarvestParamsForm(frm){
 		(frm.local.value.trim() == '') && (frm.elevlow.value.trim() == '') && (frm.upperlat.value.trim() == '') && (frm.footprintwkt.value.trim() == '') && (frm.pointlat.value.trim() == '') &&
 		(frm.collector.value.trim() == '') && (frm.collnum.value.trim() == '') && (frm.eventdate1.value.trim() == '') && (frm.catnum.value.trim() == '') &&
 		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false)){
-		alert("Please fill in at least one search parameter!");
-		return false;
+			//Check trait search fields if present
+			if (typeof frm.SearchByTraits !== "undefined" && frm.SearchByTraits.value == "true") {
+				var traitinputs = frm.elements;
+				var traitselected = false;
+			 	for(var i = 0; i < traitinputs.length; i++) {
+					if(traitinputs[i].name.indexOf('traitid-') == 0) {
+						if(traitinputs[i].type == 'checkbox' || traitinputs[i].type == 'radio') {
+							if(traitinputs[i].checked == true) {
+								traitselected = traitinputs[i].checked;
+								break;
+							}
+						} else {
+							if(traitinputs[i].value.trim() !== '') {
+								traitselected = true;
+								break;
+							}
+						}
+					}
+				}
+				if(!traitselected) {
+					alert("Please fill in at least one search parameter!");
+					return false;
+				}
+			} else {
+				alert("Please fill in at least one search parameter!");
+				return false;
+			}
 	}
 
 	if(frm.upperlat.value != '' || frm.bottomlat.value != '' || frm.leftlong.value != '' || frm.rightlong.value != ''){
@@ -70,7 +95,7 @@ function setHarvestParamsForm(){
 	if(sessionStorage.querystr){
 		var urlVar = parseUrlVariables(sessionStorage.querystr);
 		var frm = document.harvestparams;
-		
+
 		if(typeof urlVar.usethes !== 'undefined' && (urlVar.usethes == "" || urlVar.usethes == "0")){frm.usethes.checked = false;}
 		if(urlVar.taxontype){frm.taxontype.value = urlVar.taxontype;}
 		if(urlVar.taxa){frm.taxa.value = urlVar.taxa;}
@@ -114,6 +139,7 @@ function setHarvestParamsForm(){
 		if(typeof urlVar.hasgenetic !== 'undefined'){frm.hasgenetic.checked = true;}
 		if(typeof urlVar.includecult !== 'undefined'){frm.includecult.checked = true;}
 		if(urlVar.db){frm.db.value = urlVar.db;}
+
 	}
 }
 
@@ -121,7 +147,7 @@ function parseUrlVariables(varStr) {
 	var result = {};
 	varStr.split("&").forEach(function(part) {
 		if(!part) return;
-		part = part.split("+").join(" "); 
+		part = part.split("+").join(" ");
 		var eq = part.indexOf("=");
 		var key = eq>-1 ? part.substr(0,eq) : part;
 		var val = eq>-1 ? decodeURIComponent(part.substr(eq+1)) : "";

--- a/js/symb/collections.harvestparams.js
+++ b/js/symb/collections.harvestparams.js
@@ -139,7 +139,13 @@ function setHarvestParamsForm(){
 		if(typeof urlVar.hasgenetic !== 'undefined'){frm.hasgenetic.checked = true;}
 		if(typeof urlVar.includecult !== 'undefined'){frm.includecult.checked = true;}
 		if(urlVar.db){frm.db.value = urlVar.db;}
-
+		for(var i in urlVar) {
+			if(`${i}`.indexOf('traitid-') == 0) {
+				var traitInput = document.getElementById("traitstateid-" + urlVar[i]);
+				if(traitInput.type == 'checkbox' || traitInput.type == 'radio') { traitInput.checked = true; };
+				// if(traitInput.type == 'select') { traitInput.value = urlVar[i]; }; // Must improve this to deal with multiple possible selections
+			}
+		}
 	}
 }
 

--- a/js/symb/collections.traitsearch.js
+++ b/js/symb/collections.traitsearch.js
@@ -1,0 +1,52 @@
+// The following functions enable some of the search-by-trait functionality
+// added for the CCH2 TCN. Code is modified from collections.traitattr.js
+
+$(document).ready(function() {
+	setAttributeTree(null);
+	$(".trianglediv").each(function(){
+		var rootElem = $(this).closest("fieldset");
+		var childClassArr = $(rootElem).find("div[class^=child]");
+		if(childClassArr.length == 0) $(this).hide();
+	});
+});
+
+function traitChanged(elem){
+	var elemType =  elem.getAttribute("type");
+	var elemName = elem.getAttribute("name");
+	var traitID = elemName.substring(8,elemName.length-2);
+	if(elem.checked == true){
+    elem.checked == false;
+	}
+	if(!sessionStorage.attributeTree || sessionStorage.attributeTree == 0){
+		$('input[name="traitid-'+traitID+'[]"]').each(function(){
+			if((elemType == 'text' && elemType.value.trim() != '') || this.checked == true){
+				if(sessionStorage.attributeTree == 0) $("div.child-"+this.value).show();
+			}  // Expands the attribute tree if hidden, but intentionally does not re-hide
+		});
+	}
+}
+
+function setAttributeTree(triggerElem){
+	var toggleTree = false;
+	if(triggerElem) toggleTree = true;
+	var treeOpen = false;
+	if(sessionStorage.attributeTree && sessionStorage.attributeTree == 1) treeOpen = true;
+	if(toggleTree){
+		if(treeOpen) treeOpen = false;
+		else treeOpen = true;
+	}
+	var rootElem = $("#traitdiv");
+	if(triggerElem) rootElem = $(triggerElem).closest("fieldset");
+	if(treeOpen){
+		$(rootElem).find("div[class^=child]").show();
+		$(rootElem).find(".triangledown").show();
+		$(rootElem).find(".triangleright").hide();
+		sessionStorage.attributeTree = 1;
+	}
+	else{
+		$(rootElem).find("div[class^=child]").hide();
+		$(rootElem).find('.triangledown').hide();
+		$(rootElem).find('.triangleright').show();
+		sessionStorage.attributeTree = 0;
+	}
+}


### PR DESCRIPTION
Ed,
This branch allows for searching by traits in the text-based search (harvestparams.php). Portal managers select which traits they wish to have searchable by listing the trait id numbers in a comma separated string in symbini.php ($SEARCH_BY_TRAITS variable). A zero in $SEARCH_BY_TRAITS (default in template) producing the base harvestparams.php.
I have created a new extension of class OccurrenceAttributes called OccurrenceAttributeSearch. This child class has a few parallel methods for echoing the trait form and getting and setting the search array. OccurrenceAttributeSearch uses the parent class's $traitArr property and setDependentTraits() and setTraitStates() methods. Thus the visibility of these elements were upgraded to protected. The main change is adding a unique id to the input tags so that getElementById() can be used to when users return to the search form from a result list and these fields properly repopulate. The get/set methods are different so that they can accommodate the portal managers choosing different traits to be searchable without affecting how these methods work for editing specimen attributes.
The search works by sending the trait state values to the querystr and OccurrenceManager has been modified to parse these into a WHERE clause. Currently, this performs the equivant of an 'OR' search by using the stateid IN(...). The potential for an AND vs OR was discussed with Jenn and Katie and Jenn preferred the OR behavior. I chose to indicate the search criteria as "Trait Name: State Name". Depending on how users encode their traits, this could get lengthy, but the alternatives were just trait name or just state name, which seemed ambiguous (e.g. "Open Flowers: present" vs. just "Open Flowers" or just "present").
The collections.traitsearch.js file was modified to accommodate checking for blanks (or not) in the trait search form when active.
In addition, a new javascript file was created (collections.traitsearch.js) to handle the trait form behavior on harvestparams. This was customized from collections.traitattr.js.
Support for English and Spanish languages has been added for the new Symbiota elements I created, but the dynamic, user created items like trait names and states will appear as entered.

Left outstanding is the ability to repopulate input type="select" fields, because selects can have multiple options selected and I just ran out of time to investigate this. So, when users return to the Search Criterion page from a results list, any select-type controls for traits will be reset.